### PR TITLE
Function calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ compiled/
 \#*
 .\#*
 temp.j
+*.java

--- a/binding.rkt
+++ b/binding.rkt
@@ -9,19 +9,11 @@
 (provide binding-lookup binding-status binding-set binding-create
          binding-unbound binding-uninit binding-init empty-stt
          binding-push-layer binding-pop-layer
-         binding-layer-idx binding-state-by-layer-idx
-         binding-callstack)
-
-(define (binding-callstack state)
-  (if (stt-empty? state)
-      ""
-      (~a (lyr-meta-description (stt-first-lyr state))
-          " > "
-          (binding-callstack (stt-rest-lyrs state)))))
+         binding-layer-idx binding-state-by-layer-idx)
 
 ; Return the state with an empty layer added
-(define (binding-push-layer state is-func-layer? layer-description)
-  (cons (empty-lyr (if is-func-layer? meta-func-lyr meta-normal-lyr) layer-description) state))
+(define (binding-push-layer state is-func-layer?)
+  (cons (empty-lyr (if is-func-layer? meta-func-lyr meta-normal-lyr)) state))
 
 ; Return the state with the first layer removed
 (define (binding-pop-layer state)
@@ -123,9 +115,9 @@
 (define meta-func-lyr 'func-layer)
 (define meta-normal-lyr 'normal-layer)
 
-(define (empty-lyr lyr-type lyr-desc)
-  (list (list lyr-type lyr-desc) '() '()))
-(define empty-stt (list (empty-lyr meta-normal-lyr "global scope")))
+(define (empty-lyr lyr-type)
+  (list (list lyr-type) '() '()))
+(define empty-stt (list (empty-lyr meta-normal-lyr)))
 
 (define (lyr-empty? layer)
   (or (null? (lyr-names layer))
@@ -134,7 +126,6 @@
 
 (define lyr-meta car)
 (define (lyr-meta-type layer) (car (lyr-meta layer)))
-(define (lyr-meta-description layer) (cadr (lyr-meta layer)))
 (define lyr-names cadr)
 (define lyr-vals caddr)
 

--- a/common.rkt
+++ b/common.rkt
@@ -6,7 +6,7 @@
 ;;;; Group Project 3: Imperative Language Interpreter
 ;;;; ***************************************************
 
-(provide not-null? in-list? not-equal?)
+(provide not-null? in-list? not-equal? same-length?)
 
 ; returns true if a is not null; false otherwise
 (define (not-null? a) (not (null? a)))
@@ -21,3 +21,9 @@
 ; returns true if a does not equal b
 (define (not-equal? a b)
   (not (equal? a b)))
+
+(define (same-length? lis1 lis2)
+  (cond
+    [((null? lis1) . and . (null? lis2)) #t]
+    [((null? lis1) . or . (null? lis2)) #f]
+    [else (same-length? (cdr lis1) (cdr lis2))]))

--- a/main.rkt
+++ b/main.rkt
@@ -277,17 +277,21 @@
 ; get value of a function call
 (define (value-func-call func-call state return next throw)
   (let ([closure (binding-lookup (func-call-name func-call) state)])
-    (state-statement-list (closure-body closure)
-                          (bind-params (closure-formal-params closure)
-                                       (func-call-actual-params func-call)
-                                       (binding-push-layer ((closure-scope-func closure) state) #t)
-                                       state
-                                       throw)
-                          return
-                          next
-                          (lambda (s) (throw (~a "Break outside of loop in function " (func-call-name func-call))))
-                          (lambda (s) (throw (~a "Continue outside of loop in function " (func-call-name func-call))))
-                          (lambda (e s) (throw e state)))))
+    (if (not (same-length? (closure-formal-params closure) (func-call-actual-params func-call)))
+        (throw (~a "Function called with wrong number of parameters. Expected "
+                   (length (closure-formal-params closure)) ", got "
+                   (length (func-call-actual-params func-call)) ".") state)
+        (state-statement-list (closure-body closure)
+                              (bind-params (closure-formal-params closure)
+                                           (func-call-actual-params func-call)
+                                           (binding-push-layer ((closure-scope-func closure) state) #t)
+                                           state
+                                           throw)
+                              return
+                              next
+                              (lambda (s) (throw (~a "Break outside of loop in function " (func-call-name func-call))))
+                              (lambda (s) (throw (~a "Continue outside of loop in function " (func-call-name func-call))))
+                              (lambda (e s) (throw e state))))))
 
 ; get the value of expression, regardless of type or operator aryness
 (define (value-generic expression state next throw)

--- a/main.rkt
+++ b/main.rkt
@@ -6,7 +6,7 @@
 ;;;; Group Project 3: Imperative Language Interpreter
 ;;;; ***************************************************
 
-(require "parser/parser.rkt" "binding.rkt" "value.rkt" "common.rkt")
+(require "parser/parser.rkt" "binding.rkt" "common.rkt")
 (provide interpret interpret-tree state-block)
 
 ; Takes a filename, calls specified parser with the filename, and returns the proper value
@@ -231,3 +231,181 @@
 (define func-dec-name car)
 (define func-dec-formal-params cadr)
 (define func-dec-body caddr)
+
+
+;;;; ===================================================
+;;;; Value
+;;;; ===================================================
+
+
+; get value of expression, assuming expression uses a binary operator
+(define (value-binary-operator expression state next throw)
+  (value-generic (first-operand-literal expression) state
+                 (lambda (op1)
+                   (value-generic (second-operand-literal expression) state
+                                  (lambda (op2)
+                                    (let ([op (operator expression)])
+                                      (cond
+                                        [(eq? '+  op) (next (op-plus   op1 op2))]
+                                        [(eq? '-  op) (next (op-minus  op1 op2))]
+                                        [(eq? '*  op) (next (op-times  op1 op2))]
+                                        [(eq? '/  op) (next (op-divide op1 op2))]
+                                        [(eq? '%  op) (next (op-modulo op1 op2))]
+                                        [(eq? '== op) (next (cond-eq   op1 op2))]
+                                        [(eq? '!= op) (next (cond-neq  op1 op2))]
+                                        [(eq? '>  op) (next (cond-gt   op1 op2))]
+                                        [(eq? '<  op) (next (cond-lt   op1 op2))]
+                                        [(eq? '<= op) (next (cond-leq  op1 op2))]
+                                        [(eq? '>= op) (next (cond-geq  op1 op2))]
+                                        [(eq? '&& op) (next (bool-and  op1 op2 throw))]
+                                        [(eq? '|| op) (next (bool-or   op1 op2 throw))]
+                                        [else (throw (~a "Invalid binary operator: " op) state)]))) throw))
+                 throw))
+
+; get value of expression, assuming expression uses a unary operator
+(define (value-unary-operator expression state next throw)
+  (value-generic (first-operand-literal expression) state
+                 (lambda (op1)
+                   (let ([op (operator expression)])
+                     (cond
+                       [(eq? '- op)  (next (op-unary-minus op1 throw))]
+                       [(eq? '! op)  (next (bool-not       op1 throw))]
+                       [else (throw (~a "Invalid unary operator: " op))])))
+                 throw))
+
+; get value of a function call
+(define (value-func-call func-call state handle-next next throw)
+  (let ([closure (binding-lookup (func-call-name func-call) state)])
+    (state-block (closure-body closure)
+                 (bind-params (closure-formal-params closure)
+                              (func-call-actual-params func-call)
+                              (binding-push-layer ((closure-scope-func closure) state))
+                              state
+                              throw)
+                 handle-next
+                 (lambda (v) (next v))
+                 (lambda (s) (throw (~a "Break outside of loop in function " (func-call-name func-call))))
+                 (lambda (s) (throw (~a "Continue outside of loop in function " (func-call-name func-call))))
+                 (lambda (e s) (throw e state)))))
+
+; get the value of expression, regardless of type or operator aryness
+(define (value-generic expression state next throw)
+  (cond
+    [(number? expression) (next expression)]
+    [(boolean-literal? expression) (next expression)]
+    [(eq? (binding-status expression state) binding-init) (next (binding-lookup expression state))]
+    [(eq? (binding-status expression state) binding-uninit) (error (~a expression " has not been assigned a value"))]
+    [(not (pair? expression)) (error (~a expression " has not been declared"))]
+    [(eq? (expr-start expression) 'funcall)
+     (value-func-call (expr-func-call expression)
+                      state
+                      (lambda (s) (throw (~a "No return statement in function " (func-call-name (expr-func-call expression))) state))
+                      next
+                      throw)]
+    [(has-second-operand? expression) (value-binary-operator expression state next throw)]
+    [(has-first-operand? expression) (value-unary-operator expression state next throw)]
+    [else (throw (~a "Invalid operator: " (operator expression)))]))
+
+; ======================================================
+; Operations
+
+; Create binary boolean condition function that returns atom 'true/'false from racket function that
+;  returns #t/#f
+(define (build-condition racket-op)
+  (lambda (op1 op2)
+    (if (racket-op op1 op2)
+        'true
+        'false)))
+
+; Create function that runs racket-op on two inputs but errors if either input is not an integer
+; op-atom is an atom that describes the operation for use in error printing
+(define (typesafe-binary-int-op racket-op op-atom)
+  (typesafe-binary-op racket-op op-atom integer? 'integer))
+
+; Create function that runs racket-op on one input but errors if the input is not an integer
+; op-atom is an atom that describes the operation for use in error printing
+(define (typesafe-unary-int-op racket-op op-atom)
+  (typesafe-unary-op racket-op op-atom integer? 'integer))
+
+; Create function that runs racket-op on two inputs but errors if either input fails predicate
+; op-atom & predicate-atom are atoms that describe the operation & predicate for use in error printing
+(define (typesafe-binary-op racket-op op-atom predicate predicate-atom)
+  (lambda (op1 op2)
+    (cond
+      [(not (predicate op1)) (error (~a "Invalid left hand side of operator " op-atom ": expected " predicate-atom ", got " op1))]
+      [(not (predicate op2)) (error (~a "Invalid right hand side of operator " op-atom ": expected " predicate-atom ", got " op2))]
+      [else (racket-op op1 op2)])))
+
+; Create function that runs racket-op on one input but errors if the input fails predicate
+; op-atom & predicate-atom are atoms that describe the operation & predicate for use in error printing
+(define (typesafe-unary-op racket-op op-atom predicate predicate-atom)
+  (lambda (op1 throw)
+    (cond
+      [(not (predicate op1)) (throw (~a "Invalid operand of operator " op-atom ": expected " predicate-atom ", got " op1))]
+      [else (racket-op op1)])))
+
+(define cond-eq  (build-condition equal?))
+(define cond-neq (build-condition not-equal?))
+(define cond-gt  (build-condition (typesafe-binary-int-op > '>)))
+(define cond-lt  (build-condition (typesafe-binary-int-op < '<)))
+(define cond-geq (build-condition (typesafe-binary-int-op >= '>=)))
+(define cond-leq (build-condition (typesafe-binary-int-op <= '<=)))
+
+(define op-plus   (typesafe-binary-int-op + '+))
+(define op-minus  (typesafe-binary-int-op - '-))
+(define op-times  (typesafe-binary-int-op * '*))
+(define op-divide (typesafe-binary-int-op quotient '/))
+(define op-modulo (typesafe-binary-int-op remainder '%))
+
+(define op-unary-minus (typesafe-unary-int-op (lambda (v) (- 0 v)) "unary -"))
+
+; boolean not using 'true/'false atoms
+; errors on operand that isn't a boolean atom
+(define (bool-not op1 throw)
+  (cond
+    [(eq? op1 'true) 'false]
+    [(eq? op1 'false) 'true]
+    [else (throw "Inversion can only be applied to booleans")]))
+
+; boolean and using 'true/'false atoms with explicit short circuiting
+; errors on operands that aren't boolean atoms
+(define (bool-and op1 op2 throw)
+  (cond
+    [(eq?        op1 'false)  'false]
+    [(not-equal? op1 'true) (throw (~a "And can only be applied to booleans, got " op1))]
+    [(eq?        op2 'false)  'false]
+    [(not-equal? op2 'true) (throw (~a "And can only be applied to booleans, got " op2))]
+    [else 'true]))
+
+; boolean or using 'true/'false atoms with explicit short circuiting
+; errors on operands that aren't boolean atoms
+(define (bool-or op1 op2 throw)
+  (cond
+    [(eq?        op1 'true)  'true]
+    [(not-equal? op1 'false) (throw (~a "Or can only be applied to booleans, got " op1))]
+    [(eq?        op2 'true)  'true]
+    [(not-equal? op2 'false) (throw (~a "Or can only be applied to booleans, got " op2))]
+    [else 'false]))
+
+; ======================================================
+; Value Abstractions
+
+; return true if expression is a boolean atom ('true or 'false)
+(define (boolean-literal? expression) (or (eq? expression 'true) (eq? expression 'false)))
+
+(define (has-second-operand? expression) (not-null? (cddr expression)))
+(define (has-first-operand? expression) (not-null? (cdr expression)))
+
+(define operator car)
+(define first-operand-literal cadr)
+(define second-operand-literal caddr)
+
+(define first-param car)
+(define next-params cdr)
+(define expr-start car)
+(define expr-func-call cdr)
+(define func-call-name car)
+(define func-call-actual-params cdr)
+(define closure-formal-params car)
+(define closure-body cadr)
+(define closure-scope-func caddr)

--- a/main.rkt
+++ b/main.rkt
@@ -20,9 +20,9 @@
                         empty-stt
                         (lambda (s) binding-uninit)
                         (lambda (v) v)
-                        (lambda (s) (error (~a "'break' called outside loop in " (binding-callstack s))))
-                        (lambda (s) (error (~a "'continue' called outside loop in " (binding-callstack s))))
-                        (lambda (e s) (error (~a "Error: " e " in " (binding-callstack s))))))
+                        (lambda (s) (error (~a "'break' called outside loop")))
+                        (lambda (s) (error (~a "'continue' called outside loop")))
+                        (lambda (e s) (error (~a "Error: " e)))))
 
 ; Returns the return value after recursing through a series of statement lists
 (define (state-statement-list tree state next return break continue throw)
@@ -60,7 +60,7 @@
 ; Returns state after running a block of statements
 (define (state-block body state next return break continue throw)
   (state-statement-list body
-                        (binding-push-layer state #f "block")
+                        (binding-push-layer state #f)
                         (lambda (s) (next (binding-pop-layer s)))
                         return
                         (lambda (s) (break (binding-pop-layer s)))
@@ -279,7 +279,7 @@
     (state-block (closure-body closure)
                  (bind-params (closure-formal-params closure)
                               (func-call-actual-params func-call)
-                              (binding-push-layer ((closure-scope-func closure) state) #t (func-call-name func-call))
+                              (binding-push-layer ((closure-scope-func closure) state) #t)
                               state
                               throw)
                  handle-next

--- a/main.rkt
+++ b/main.rkt
@@ -7,7 +7,7 @@
 ;;;; ***************************************************
 
 (require "parser/parser.rkt" "binding.rkt" "common.rkt")
-(provide interpret interpret-tree state-block)
+(provide interpret interpret-tree)
 
 ; Takes a filename, calls specified parser with the filename, and returns the proper value
 (define (interpret filename [parser-str function-parser-str])

--- a/tester.rkt
+++ b/tester.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "state.rkt" "parser/parser.rkt")
+(require "main.rkt" "parser/parser.rkt")
 (require html-parsing)  ; raco pkg install html-parsing
 (require ansi-color)    ; raco pkg install ansi-color
 (provide


### PR DESCRIPTION
- Function calls
- main.rkt is currently value.rkt and state.rkt pasted together, changes to original files are shown
- Replaced `return` with `next` in value.rkt
- Changed return continuation in state.rkt to not take state as an argument

"Passes" all test cases, including previous parts (using makeshift testing for part 3) except:
- 5, 6, 14, 15, 17 (error that bindings already exist, but bindings with same name should be allowed)
- 12 (not handling error properly)
- 16 (cdr contract violation - something wrong with function call state layers?)

Also throws in most value functions currently don't take a state, not sure how to handle yet